### PR TITLE
chore: exclude gridgen from pymake build

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, macos-13, macos-14, windows-2019 ]
+        os: [ ubuntu-22.04, macos-13, macos-14, windows-2022 ]
     defaults:
       run:
         shell: bash -l {0}
@@ -86,7 +86,7 @@ jobs:
           command: |
             ostag="${{ steps.ostag.outputs.ostag }}"
             mkdir $ostag
-            make-program : --appdir $ostag --zip $ostag.zip --verbose
+            make-program : --appdir $ostag -ex gridgen --zip $ostag.zip --verbose
             make-program mf2005,mflgr,mfnwt,mfusg --appdir $ostag --double --keep --zip $ostag.zip --verbose
             if [[ "${{ matrix.os }}" == "macos-14" ]]; then
               make-program mf6 --appdir $ostag --keep --zip $ostag.zip --verbose --fflags='-O1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14, windows-2019]
+        os: [ubuntu-22.04, macos-13, macos-14, windows-2022]
     defaults:
       run:
         shell: bash
@@ -90,7 +90,7 @@ jobs:
           command: |
             ostag="${{ steps.ostag.outputs.ostag }}"
             mkdir $ostag
-            make-program : --appdir $ostag --zip $ostag.zip --verbose
+            make-program : --appdir $ostag -ex gridgen --zip $ostag.zip --verbose
             make-program mf2005,mflgr,mfnwt,mfusg --appdir $ostag --double --keep --zip $ostag.zip --verbose
             if [[ "${{ matrix.os }}" == "macos-14" ]]; then
               make-program mf6 --appdir $ostag --keep --zip $ostag.zip --verbose --fflags='-O1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 wheel
-https://github.com/modflowpy/pymake/zipball/develop
-https://github.com/MODFLOW-ORG/modflow-devtools/zipball/develop
+https://github.com/modflowpy/pymake/archive/develop.zip
+https://github.com/MODFLOW-ORG/modflow-devtools/archive/develop.zip


### PR DESCRIPTION
also use uv-compatible github repo dependency syntax in requirements.txt, and bump windows-2019 to 2022